### PR TITLE
chore: migrate GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Set up Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - name: Set up Rust
@@ -73,7 +73,7 @@ jobs:
           $lines | Set-Content -LiteralPath "$bundle/SHA256SUMS.txt" -Encoding utf8
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           draft: true
           prerelease: ${{ contains(github.ref_name, '-rc') }}


### PR DESCRIPTION
## Summary

Update the repository's GitHub Actions workflows to current Node 24-compatible action releases.

### Changes

- `actions/checkout` v4 → v7
- `actions/setup-node` v4 → v7
- workflow build runtime Node.js 20 → 24
- `softprops/action-gh-release` v2 → v3

### Scope

Only the CI and release workflow files are changed:

- `.github/workflows/ci.yml`
- `.github/workflows/release.yml`

Application source code, application dependencies, Rust dependencies, and release artifacts are unchanged.

### Validation

Validated locally on Windows with Node.js 24:

- `npm ci` ✅
- frontend production build ✅
- secret scan ✅
- `cargo fmt` ✅
- `cargo check` ✅
- `cargo test` ✅
- `cargo clippy -- -D warnings` ✅
- Tauri production build ✅
- Windows EXE / MSI / NSIS packaging ✅

This PR is intended to additionally validate the updated actions on GitHub-hosted Windows runners before merging.